### PR TITLE
Update tlStructGenerator.go

### DIFF
--- a/cmd/tlgenerator/tlStructGenerator.go
+++ b/cmd/tlgenerator/tlStructGenerator.go
@@ -382,7 +382,7 @@ func generateStructsFromTnEntities(
 				}
 			}
 
-			illStr := `fmt.Errorf("error! code: %d msg: %s", result.Data["code"], result.Data["message"])`
+			illStr := `fmt.Errorf("error! code: %v msg: %s", result.Data["code"], result.Data["message"])`
 			if strings.Contains(paramsStr, returnTypeCamel) {
 				returnTypeCamel = returnTypeCamel + "Dummy"
 			}


### PR DESCRIPTION
change formatter for error code (now it has float64 type and can't be printed as %d)
``` error! code: %!d(float64=500) msg: LITE_SERVER_NETWORKadnl query timeout ```